### PR TITLE
Create moto-msm8992.xml

### DIFF
--- a/moto-msm8992.xml
+++ b/moto-msm8992.xml
@@ -1,0 +1,18 @@
+<manifest>
+
+  <!-- Motorola MSM8992 -->
+  <project name="CyanogenMod/android_device_motorola_clark" path="device/motorola/clark" remote="github" revision="cm-14.0" />
+  <project name="CyanogenMod/android_device_motorola_qcom-common" path="device/motorola/qcom/common" remote="github" revision="cm-14.0" />
+  <project name="CyanogenMod/android_kernel_motorola_msm8992" path="kernel/motorola/msm8992" remote="github" revision="cm-14.0" />
+  <project name="CyanogenMod/android_external_bson" path="external/bson" remote="github" revision="cm-14.1" />
+  <project name="CyanogenMod/android_external_connectivity" path="external/connectivity" remote="github" revision="cm-14.0" />
+  <project name="CyanogenMod/android_vendor_qcom_opensource_dataservices" path="vendor/qcom/opensource/dataservices" remote="github" revision="cm-14.0" />
+  <project name="TheMuppets/proprietary_vendor_motorola" path="vendor/motorola" remote="github" revision="cm-14.0" />
+<project name="TheMuppets/proprietary_vendor_qcom_binaries" path="vendor/qcom/binaries" remote="github" revision="cm-14.1" />
+
+  <!-- QCOM HALs -->
+  <project path="hardware/qcom/audio-caf/msm8992" name="omnirom/android_hardware_qcom_audio-caf-msm8992" groups="qcom,qcom_audio" remote="github" revision="android-7.0" />
+  <project path="hardware/qcom/display-caf/msm8992" name="omnirom/android_hardware_qcom_display-caf-msm8992" groups="pdk,qcom,qcom_display" remote="github" revision="android-7.0" />
+  <project path="hardware/qcom/media-caf/msm8992" name="omnirom/android_hardware_qcom_media-caf-msm8992" groups="qcom" remote="github" revision="android-7.0" />
+
+</manifest>


### PR DESCRIPTION
<manifest>

  <!-- Motorola MSM8992 -->
  <project name="CyanogenMod/android_device_motorola_clark" path="device/motorola/clark" remote="github" revision="cm-14.0" />
  <project name="CyanogenMod/android_device_motorola_qcom-common" path="device/motorola/qcom/common" remote="github" revision="cm-14.0" />
  <project name="CyanogenMod/android_kernel_motorola_msm8992" path="kernel/motorola/msm8992" remote="github" revision="cm-14.0" />
  <project name="CyanogenMod/android_external_bson" path="external/bson" remote="github" revision="cm-14.1" />
  <project name="CyanogenMod/android_external_connectivity" path="external/connectivity" remote="github" revision="cm-14.0" />
  <project name="CyanogenMod/android_vendor_qcom_opensource_dataservices" path="vendor/qcom/opensource/dataservices" remote="github" revision="cm-14.0" />
  <project name="TheMuppets/proprietary_vendor_motorola" path="vendor/motorola" remote="github" revision="cm-14.0" />
<project name="TheMuppets/proprietary_vendor_qcom_binaries" path="vendor/qcom/binaries" remote="github" revision="cm-14.1" />

  <!-- QCOM HALs -->
  <project path="hardware/qcom/audio-caf/msm8992" name="omnirom/android_hardware_qcom_audio-caf-msm8992" groups="qcom,qcom_audio" remote="github" revision="android-7.0" />
  <project path="hardware/qcom/display-caf/msm8992" name="omnirom/android_hardware_qcom_display-caf-msm8992" groups="pdk,qcom,qcom_display" remote="github" revision="android-7.0" />
  <project path="hardware/qcom/media-caf/msm8992" name="omnirom/android_hardware_qcom_media-caf-msm8992" groups="qcom" remote="github" revision="android-7.0" />

</manifest>